### PR TITLE
Add ability to show all notes with a sequence in dynamic block

### DIFF
--- a/denote-org.el
+++ b/denote-org.el
@@ -974,7 +974,7 @@ DEPTH of the root FILE is 1. Using 2 lists children, 3 grandchildren, and so on.
     (interactive
      (list
       (denote-sequence-file-prompt "List descendants of")
-      (denote-sequence-depth-prompt "Maximum relative depth from root node: "))
+      (denote-sequence-depth-prompt "Maximum relative depth from root node: " 2))
      org-mode)
     (org-create-dblock (list :name "denote-sequence"
                              :sequence (denote-retrieve-filename-signature file)

--- a/denote-org.el
+++ b/denote-org.el
@@ -974,7 +974,7 @@ DEPTH of the root FILE is 1. Using 2 lists children, 3 grandchildren, and so on.
     (interactive
      (list
       (denote-sequence-file-prompt "List descendants of")
-      (denote-sequence-depth-prompt "Maximum relative depth from root node: " 2))
+      (denote-sequence-depth-prompt "Maximum relative depth from root node: "))
      org-mode)
     (org-create-dblock (list :name "denote-sequence"
                              :sequence (denote-retrieve-filename-signature file)

--- a/denote-org.el
+++ b/denote-org.el
@@ -1027,11 +1027,13 @@ When sequence is an empty string, then use all Denote files with a sequence.
 Used by `org-dblock-update' with PARAMS provided by the dynamic block."
     (let ((block-name (plist-get params :block-name))
           (depth (plist-get params :depth)))
-      (when-let* ((sequence (plist-get params :sequence))
-                  (parent (denote-sequence-get-path sequence))
-                  (children (denote-sequence-get-relative sequence 'all-children))
-                  (family (push parent children))
-                  (files (denote-org-sequence--get-files-with-max-depth depth family)))
+      (let* ((sequence (plist-get params :sequence))
+             (parent (denote-sequence-get-path sequence))
+             (children (denote-sequence-get-relative sequence 'all-children))
+             (family (if (eq sequence "")
+			 nil
+		       (push parent children)))
+             (files (denote-org-sequence--get-files-with-max-depth depth family)))
         (when block-name (insert "#+name: " block-name "\n"))
         (denote-org--insert-sequence files)
         (join-line)))))


### PR DESCRIPTION
Hi Prot,

This change enables users to add all notes with a sequence to a dynamic block. A use case is to show all root nodes in your collection to create a table of contents of the Denote directory, e.g.:

```
#+BEGIN: denote-sequence :sequence "" :depth 1
- 1: Philosophy
- 2: Religion
- 3: Social science
- ...
#+END:
```

This request also reverts pull request https://github.com/protesilaos/denote-org/pull/12.

P:)

