### PR TITLE
Add heading offset with `:heading-level` 

### DIFF
--- a/README.org
+++ b/README.org
@@ -272,7 +272,7 @@ or manually write the following block in an Org file and then type
  =C-c C-x C-u= (~org-dblock-update~) on the =#+BEGIN= line to run it
 (do it again to recalculate the block):
 
-: #+BEGIN: denote-files :regexp "YOUR REGEXP HERE" :not-regexp nil :sort-by-component nil :reverse-sort nil :no-front-matter nil :file-separator nil :add-links nil
+: #+BEGIN: denote-files :regexp "YOUR REGEXP HERE" :not-regexp nil :sort-by-component nil :reverse-sort nil :no-front-matter nil :file-separator nil :add-links nil :heading-level nil
 :
 : #+END:
 
@@ -355,6 +355,17 @@ parameters, which are described further below:
   Org can fold the items in a typographic list the same way it does
   with headings. So even long files can be presented in this format
   without much trouble.
+
+- The =:heading-level= parameter is optional. It controls the heading
+  levels for inserted file content. When nil (the default), headings in
+  the file content are left unchanged. This parameter supports two modes:
+  - An integer >= 1 (absolute mode): Sets the minimum content heading to
+    a specific level. Content headings are shifted so the minimum heading
+    in the file becomes the specified level. For example, =:heading-level 2=
+    makes the minimum content heading =**=.
+  - A string like ="+2"= or ="-1"= (relative mode): Applies a fixed offset
+    to all content headings. For example, =:heading-level "+2"= adds two
+    levels to all headings.
 
 - An optional =:block-name= parameter can be specified with a string
   value to add a =#+name= to the results. This is useful for further

--- a/README.org
+++ b/README.org
@@ -393,7 +393,7 @@ In its simplest form, this dynamic block looks like this, with
 Though when you use the command ~denote-org-dblock-insert-files-as-headings~
 you get all the parameters included:
 
-: #+BEGIN: denote-files-as-headings :regexp "YOUR REGEXP HERE" :not-regexp nil :excluded-dirs-regexp nil :sort-by-component title :reverse-sort nil :add-links nil :exclude-tags nil
+: #+BEGIN: denote-files-as-headings :regexp "YOUR REGEXP HERE" :not-regexp nil :excluded-dirs-regexp nil :sort-by-component title :reverse-sort nil :add-links nil :exclude-tags nil :title-heading-level 1 :heading-level "+1"
 :
 : #+END:
 
@@ -445,6 +445,32 @@ you get all the parameters included:
   =#+filetags= of the matching file are appended to the title as tags.
   This is what happens by default. If =:exclude-tags= is non-nil, then
   the tags are omitted.
+
+- The =:title-heading-level= parameter is optional. It controls the
+  heading level for the file title. When nil, defaults to 1 (making
+  the title a top-level heading =*=). Must be an integer >= 1.
+  For example, =:title-heading-level 2= makes the title a level-2
+  heading =**=.
+
+- The =:heading-level= parameter is optional. It controls the heading
+  levels for file content. When nil, defaults to ="+1"= (add one level
+  to all content headings, which is the current behavior). This
+  parameter supports two modes:
+  - *Absolute mode* (integer >= 1): Set the minimum content heading to
+    a specific level. Content headings are shifted so the minimum
+    heading in the file becomes the specified level. For example,
+    =:heading-level 2= makes the minimum content heading =**=. If the
+    original file has =***= and =****=, they become =**= and =***=.
+  - *Relative mode* (string like ="+2"= or ="-1"=): Apply a fixed
+    offset to all content headings. For example, =:heading-level "+2"=
+    adds two levels to all headings, and =:heading-level "-1"=
+    subtracts one level (clamped to a minimum of level 1).
+
+  The =:title-heading-level= and =:heading-level= parameters work
+  independently, allowing fine control over document structure. For
+  example, you can have the title at level 2 and content minimum at
+  level 2 (same level), or title at level 1 and content minimum at
+  level 2 (making content sub-headings of the title).
 
 - An optional =:block-name= parameter can be specified with a string
   value to add a =#+name= to the results. This is useful for further

--- a/denote-org.el
+++ b/denote-org.el
@@ -636,7 +636,7 @@ argument.
 
 Optional HEADING-LEVEL controls the heading levels for file content.
 When nil, headings are left unchanged.  Can be an integer >= 1
-(absolute mode) or a string like \"+2\" or \"-1\" (relative mode)."
+\(absolute mode) or a string like \"+2\" or \"-1\" (relative mode)."
   (when (denote-file-has-denoted-filename-p file)
     (with-temp-buffer
       (when add-links
@@ -704,7 +704,7 @@ name matches the given regular expression.
 
 Optional HEADING-LEVEL controls the heading levels for file content.
 When nil, headings are left unchanged.  Can be an integer >= 1
-(absolute mode) or a string like \"+2\" or \"-1\" (relative mode)."
+\(absolute mode) or a string like \"+2\" or \"-1\" (relative mode)."
   (let* ((denote-excluded-directories-regexp (or excluded-dirs-regexp denote-excluded-directories-regexp))
          (files (denote-org-dblock--files regexp sort-by-component reverse exclude-regexp))
          (files-contents (mapcar
@@ -724,7 +724,7 @@ Sort the files according to SORT-BY-COMPONENT, which is a symbol
 among `denote-sort-components'.
 
 The created dynamic block has a :heading-level parameter
-(default nil) which can be modified to control heading levels in
+\(default nil) which can be modified to control heading levels in
 the inserted content.  It accepts an integer >= 1 (absolute mode)
 or a string like \"+2\" or \"-1\" (relative mode)."
   (interactive
@@ -816,8 +816,10 @@ When nil, defaults to 1.  Must be an integer >= 1.
 Optional HEADING-LEVEL controls the heading levels for file content.
 When nil, defaults to \"+1\" (add one level to all content headings).
 Can be:
-- An integer >= 1 (absolute mode): minimum content heading becomes this level
-- A string like \"+2\" or \"-1\" (relative mode): offset applied to all headings"
+- An integer >= 1 (absolute mode): minimum content heading becomes
+  this level
+- A string like \"+2\" or \"-1\" (relative mode): offset applied to
+  all headings"
   (when-let* ((_ (denote-file-has-denoted-filename-p file))
               (identifier (denote-retrieve-filename-identifier file))
               (file-type (denote-filetype-heuristics file))
@@ -839,17 +841,16 @@ Can be:
         (goto-char beginning-of-contents)
         (when (and title tags)
           (if add-links
-              (insert (format "* [[denote:%s][%s]] %s\n\n" identifier title tags))
-            (insert (format "* %s %s\n\n" title tags)))
+              (insert (format "%s [[denote:%s][%s]] %s\n\n"
+                              (make-string title-level ?*) identifier title tags))
+            (insert (format "%s %s %s\n\n"
+                            (make-string title-level ?*) title tags)))
           (unless exclude-tags
-            (org-align-tags :all)))
-        (denote-org-dblock--adjust-headings heading-level)
-        (when title-heading-level
+            (org-align-tags :all))
+          ;; Move past the title heading we just inserted
           (goto-char beginning-of-contents)
-          (when (re-search-forward "^\\*" nil t)
-            (goto-char (match-beginning 0))
-            (delete-char 1)
-            (insert (make-string title-level ?*))))
+          (forward-line 2))
+        (denote-org-dblock--adjust-headings heading-level)
         (denote-org-escape-code-in-region beginning-of-contents (point-max)))
       (buffer-string))))
 
@@ -882,8 +883,8 @@ When nil, defaults to 1.  Must be an integer >= 1.
 
 Optional HEADING-LEVEL controls the heading levels for file content.
 When nil, defaults to \"+1\" (add one level to all content headings).
-Can be an integer >= 1 (absolute mode) or a string like \"+2\" or \"-1\"
-(relative mode)."
+Can be an integer >= 1 (absolute mode) or a string like \"+2\" or
+\"-1\" (relative mode)."
   (let* ((denote-excluded-directories-regexp (or excluded-dirs-regexp denote-excluded-directories-regexp))
          (files (denote-org-dblock--files regexp sort-by-component reverse exclude-regexp))
          (files-contents (mapcar
@@ -911,11 +912,13 @@ was the #+title).
 Sort the files according to SORT-BY-COMPONENT, which is a symbol
 among `denote-sort-components'.
 
-The created dynamic block has default parameters :title-heading-level 1
-and :heading-level \"+1\", which can be modified to control heading levels:
-- :title-heading-level (integer >= 1): Sets the level for the title heading
-- :heading-level (integer >= 1 or string like \"+2\"): Controls content heading
-  levels in absolute or relative mode
+The created dynamic block has default parameters
+:title-heading-level 1 and :heading-level \"+1\", which can be
+modified to control heading levels:
+- :title-heading-level (integer >= 1): Sets the level for the
+  title heading
+- :heading-level (integer >= 1 or string like \"+2\"): Controls
+  content heading levels in absolute or relative mode
 
 IMPORTANT NOTE: This dynamic block only works with Org files, because it
 has to assume the Org notation in order to insert each file's contents

--- a/denote-org.el
+++ b/denote-org.el
@@ -789,12 +789,10 @@ HEADING-LEVEL can be an integer (absolute mode) or string like
                     value
                   (let ((min-level nil))
                     (save-excursion
-                      (goto-char (point-min))
                       (while (re-search-forward "^\\(*+\\) " nil t)
                         (let ((level (length (match-string 1))))
                           (setq min-level (if min-level (min min-level level) level)))))
                     (if min-level (- value min-level) 0)))))
-    (goto-char (point-min))
     (cond
      ((> shift 0)
       (while (re-search-forward "^\\(*+\\) " nil :no-error)


### PR DESCRIPTION
> [!NOTE]
> Bulk of the code was generated using LLM agents; I conducted manual testing and review to confirm the behaviour was correct.

Fixes #18.

## Changes

### New Helper Function
- Added `denote-org-dblock--adjust-headings`: Adjusts heading levels from current point, supporting both absolute and relative modes

### Modified Functions for `denote-files` block:
- `denote-org-dblock--get-file-contents`: Added optional `heading-level` parameter
- `denote-org-dblock-add-files`: Added optional `heading-level` parameter  
- `denote-org-dblock-insert-files`: Updated docstring and default parameters
- `org-dblock-write:denote-files`: Extract and pass `heading-level` parameter

### Modified Functions for `denote-files-as-headings` block:
- `denote-org-dblock--get-file-contents-as-heading`: Added optional `title-heading-level` and `heading-level` parameters
- `denote-org-dblock-add-files-as-headings`: Added optional `title-heading-level` and `heading-level` parameters
- `denote-org-dblock-insert-files-as-headings`: Updated docstring and default parameters
- `org-dblock-write:denote-files-as-headings`: Extract and pass both new parameters

### Documentation
- Updated README.org with parameter documentation for both dynamic blocks
- Updated function docstrings throughout

## Usage

### denote-files block:
```org
#+BEGIN: denote-files :regexp "test" :heading-level 4
#+END:
```

### denote-files-as-headings block:
```org
#+BEGIN: denote-files-as-headings :regexp "test" :title-heading-level 2 :heading-level 4
#+END:
```

## Parameter Modes

**`:heading-level`** supports two modes:
- **Absolute** (integer): `:heading-level 2` sets minimum heading to level 2
- **Relative** (string): `:heading-level "+2"` adds 2 levels to all headings

**`:title-heading-level`** (denote-files-as-headings only):
- Integer >= 1 specifying the title heading level (default: 1)

## Backward Compatibility
- All new parameters are optional with sensible defaults
- Existing dynamic blocks continue to work without modification
- Default behavior unchanged: title at level 1, content headings +1
