### PR TITLE
fix: return full file-names from denote-org--get-backlinks-for-heading

### DIFF
--- a/denote-org.el
+++ b/denote-org.el
@@ -198,10 +198,7 @@ set to `context', then return a patternf of the following form:
               (xref-file-name-display 'abs)
               (matches-in-files (xref-matches-in-files file-and-heading-id files))
               (xref-alist (xref--analyze matches-in-files)))
-    (mapcar
-     (lambda (x)
-       (denote-get-file-name-relative-to-denote-directory (car x)))
-     xref-alist)))
+    (mapcar (lambda (x) (car x)) xref-alist)))
 
 (define-obsolete-function-alias
   'denote-org-extras-backlinks-for-heading


### PR DESCRIPTION
`denote-org--get-backlinks-for-heading` is an internal function that is used in only one place: `org-dblock-write:denote-backlinks`. This function returns backlinks to a particular heading in the org file.

The default path -- getting backlinks to the whole file via `denote-get-backlinks` -- returns the absolute path of the file. This is what is expected by caller functions (eg: the
`denote--file-with-temp-buffer` call inside the macro `denote--define-retrieve-front-matter` which defines the function `denote-retrieve-front-matter-title-value`).

This commit fixes the attached backtrace by ensuring that `denote-org--get-backlinks-for-heading` also returns absolute paths.

Fixes the following backtrace:
```
  error("Cannot find anything about file `%s'" "plan/20260219T113945==51=98--plan-for-the-day-thursday-19-february-2026__standup.org")
  denote-retrieve-front-matter-title-value("plan/20260219T113945==51=98--plan-for-the-day-thursday-19-february-2026__standup.org" org)
  denote-retrieve-title-or-filename("plan/20260219T113945==51=98--plan-for-the-day-thursday-19-february-2026__standup.org" org)
  denote-link-description-with-signature-and-title("plan/20260219T113945==51=98--plan-for-the-day-thursday-19-february-2026__standup.org" nil)
  denote-get-link-description("plan/20260219T113945==51=98--plan-for-the-day-thursday-19-february-2026__standup.org")
  denote-link--prepare-links(("plan/20260219T113945==51=98--plan-for-the-day-thursday-19-february-2026__standup.org" "plan/20260223T070844==51=101--plan-for-the-day-monday-23-february-2026__standup.org") org nil :no-other-sorting)
  denote-link--insert-links(("plan/20260219T113945==51=98--plan-for-the-day-thursday-19-february-2026__standup.org" "plan/20260223T070844==51=101--plan-for-the-day-monday-23-february-2026__standup.org") org nil :no-other-sorting)
  denote-org--insert-links(("plan/20260219T113945==51=98--plan-for-the-day-thursday-19-february-2026__standup.org" "plan/20260223T070844==51=101--plan-for-the-day-monday-23-february-2026__standup.org") nil nil)
  org-dblock-write:denote-backlinks((:name "denote-backlinks" :excluded-dirs-regexp nil :sort-by-component nil :reverse-sort nil :id-only nil :this-heading-only t :include-date nil :indentation-column 0 :content #(...)))
```