### PR TITLE
fix: use renamed denote-link--ol-format-heading-description function

### DIFF
--- a/denote-org.el
+++ b/denote-org.el
@@ -151,7 +151,7 @@ Also see `denote-org-backlinks-for-heading'."
                 (heading-id (if (and context-p (null (cdr heading-data)))
                                 heading-text
                               (cdr heading-data)))
-                (description (denote-link-format-heading-description file-text heading-text)))
+                (description (denote-link--ol-format-heading-description file-text heading-text)))
       (insert
        (denote-org-format-link-with-heading
         file


### PR DESCRIPTION
Hi Prot!

I noticed that `denote-link-format-heading-description` was renamed to `denote-link--ol-format-heading-description` in the main denote package (protesilaos/denote@0a15798), but the call in `denote-org` was still using the old name.

Updated the call in `denote-org.el` line 154 and verified it works correctly.