### PR TITLE
fix: insert-missing-links should work when no links exist

### DIFF
--- a/denote-org.el
+++ b/denote-org.el
@@ -414,9 +414,9 @@ Missing links are those for which REGEXP does not have a match in
 the current buffer.
 
 EXCLUDE-REGEXP is filtered out of the matching files."
-  (when-let* ((all-files (denote-directory-files regexp :omit-current nil exclude-regexp))
-              (linked-files (denote-get-links nil all-files)))
-    (seq-difference all-files linked-files)))
+  (when-let* ((all-files (denote-directory-files regexp :omit-current nil exclude-regexp)))
+    (let ((linked-files (denote-get-links nil all-files)))
+      (seq-difference all-files linked-files))))
 
 (defun denote-org-dblock--files-missing-only (files-matching-regexp &optional sort-by-component reverse exclude-regexp)
   "Return list of missing links to FILES-MATCHING-REGEXP.


### PR DESCRIPTION
When the current file contains no links at all,
`linked-files` becomes `nil`. This is a valid value for `linked-files`, but short-circuits the `when-let*`.

The fix is to move the binding for `linked-files` into it's own let. This ensures that the `seq-difference` is actually executed.